### PR TITLE
Expose queries in Rust and Python bindings

### DIFF
--- a/bindings/python/tree_sitter_ada/__init__.py
+++ b/bindings/python/tree_sitter_ada/__init__.py
@@ -14,12 +14,12 @@ def _get_query(name, file):
 def __getattr__(name):
     # NOTE: uncomment these to include any queries that this grammar contains:
 
-    # if name == "HIGHLIGHTS_QUERY":
-    #     return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
+    if name == "HIGHLIGHTS_QUERY":
+        return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
     # if name == "INJECTIONS_QUERY":
     #     return _get_query("INJECTIONS_QUERY", "injections.scm")
-    # if name == "LOCALS_QUERY":
-    #     return _get_query("LOCALS_QUERY", "locals.scm")
+    if name == "LOCALS_QUERY":
+        return _get_query("LOCALS_QUERY", "locals.scm")
     # if name == "TAGS_QUERY":
     #     return _get_query("TAGS_QUERY", "tags.scm")
 
@@ -28,9 +28,9 @@ def __getattr__(name):
 
 __all__ = [
     "language",
-    # "HIGHLIGHTS_QUERY",
+    "HIGHLIGHTS_QUERY",
     # "INJECTIONS_QUERY",
-    # "LOCALS_QUERY",
+    "LOCALS_QUERY",
     # "TAGS_QUERY",
 ]
 

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -34,9 +34,9 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]


### PR DESCRIPTION
Thanks a lot for publishing the parser on crates.io :)

For the future, it can be useful to let Python and Rust users access the queries. Sadly it's needed to edit the auto-generated bindings for that (I'm thinking of proposing a change in tree-sitter so that they get picked up automatically)