### PR TITLE
Fix the name of license file in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
   "queries/*",
   "src/*",
   "tree-sitter.json",
-  "LICENSE",
+  "LICENSE.txt",
 ]
 
 [lib]


### PR DESCRIPTION
The license file name was mistyped, meaning it did not get picked up

```
$ cargo package --allow-dirty --list | grep LICENSE
LICENSE.txt
```